### PR TITLE
AOE disc detection: Added user input for handling german CD version

### DIFF
--- a/Age of Empires/Age of Empires - CD.txt
+++ b/Age of Empires/Age of Empires - CD.txt
@@ -17,14 +17,21 @@ installer:
     arch: win64
     name: create_prefix
     prefix: $GAMEDIR
+- input_menu:
+    description: 'Please select your CD language:'
+    id: VERSION
+    options:
+    - aoeinst.exe: English or other
+    - aoesetup.exe: German
+    preselect: aoeinst.exe
 - insert-disc:
-    requires: aoeinst.exe
+    requires: empires.ico
 - task:
     app: winxp
     name: winetricks
     prefix: $GAMEDIR
 - task:
-    args: /desktop=AgeOfEmpiresI,1024x780 $DISC/aoeinst.exe
+    args: /desktop=AgeOfEmpiresI,1024x780 $DISC/$INPUT_VERSION
     description: Installing Age of Empires I...
     executable: $GAMEDIR/drive_c/windows/explorer.exe
     name: wineexec

--- a/Age of Empires/Age of Empires - CD.txt
+++ b/Age of Empires/Age of Empires - CD.txt
@@ -1,6 +1,7 @@
 custom-name: Age of Empires I - CD
 files:
-- dxwnd: https://freefr.dl.sourceforge.net/project/dxwnd/Latest%20build/v2_05_28_build.rar
+- dxwnd: https://freefr.dl.sourceforge.net/project/dxwnd/Latest%20build/v2_05_30_build.rar
+- scriptinstall: https://raw.githubusercontent.com/BifbofII/MyLittleLutrisScripts/bugfix/aoe-ger-disc-not-found/Age%20of%20Empires/findaoe.sh
 - scriptsound: https://github.com/legluondunet/MyLittleLutrisScripts/raw/master/Age%20of%20Empires/soundtrack.bat
 - scriptclean: https://github.com/legluondunet/MyLittleLutrisScripts/raw/master/Age%20of%20Empires/clean.sh
 - gnusox: https://freefr.dl.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2-win32.zip
@@ -15,16 +16,22 @@ game:
 installer:
 - task:
     arch: win64
+    install_mono: false
     name: create_prefix
     prefix: $GAMEDIR
-- insert-disc:
-    requires: aoeinst.exe
 - task:
     app: winxp
     name: winetricks
     prefix: $GAMEDIR
+- insert-disc:
+    requires: empires.ico
+- chmodx: scriptinstall
+- execute:
+    args: $DISC
+    file: scriptinstall
+- chmodx: $GAMEDIR/installaoe.bat
 - task:
-    args: /desktop=AgeOfEmpiresI,1024x780 $DISC/aoeinst.exe
+    args: /desktop=AOEI,1024x780 $GAMEDIR/installaoe.bat
     description: Installing Age of Empires I...
     executable: $GAMEDIR/drive_c/windows/explorer.exe
     name: wineexec
@@ -111,7 +118,8 @@ installer:
     name: wineexec
     prefix: $GAMEDIR
 - input_menu:
-    description: 'Please precise your CD language:'
+    description: Please choose AOE I CD language (do not choose another language other
+      than your CD's one)
     id: LANG
     options:
     - en: English
@@ -122,11 +130,11 @@ installer:
     - po: Portuguese
     preselect: en
 - task:
-    app: directplay
+    app: icodecs
     name: winetricks
     prefix: $GAMEDIR
 - task:
-    app: icodecs
+    app: directplay
     name: winetricks
     prefix: $GAMEDIR
 - task:
@@ -138,6 +146,9 @@ installer:
     type: REG_DWORD
     value: '00000000'
 - chmodx: scriptclean
+- execute:
+    args: $INPUT_LANG "$DISC" standard
+    file: scriptclean
 - task:
     arch: win64
     key: background
@@ -146,13 +157,9 @@ installer:
     prefix: $GAMEDIR
     type: REG_SZ
     value: 0 0 0
-- execute:
-    args: $INPUT_LANG "$DISC" standard
-    file: scriptclean
 - task:
     app: win7
     name: winetricks
     prefix: $GAMEDIR
 wine:
   Desktop: true
-

--- a/Age of Empires/Age of Empires - CD.txt
+++ b/Age of Empires/Age of Empires - CD.txt
@@ -3,7 +3,7 @@ files:
 - dxwnd: https://freefr.dl.sourceforge.net/project/dxwnd/Latest%20build/v2_05_30_build.rar
 - scriptinstall: https://raw.githubusercontent.com/BifbofII/MyLittleLutrisScripts/bugfix/aoe-ger-disc-not-found/Age%20of%20Empires/findaoe.sh
 - scriptsound: https://github.com/legluondunet/MyLittleLutrisScripts/raw/master/Age%20of%20Empires/soundtrack.bat
-- scriptclean: https://github.com/legluondunet/MyLittleLutrisScripts/raw/master/Age%20of%20Empires/clean.sh
+- scriptclean: https://github.com/BifbofII/MyLittleLutrisScripts/blob/bugfix/aoe-ger-disc-not-found/Age%20of%20Empires/clean.sh
 - gnusox: https://freefr.dl.sourceforge.net/project/sox/sox/14.4.2/sox-14.4.2-win32.zip
 - mp: https://freefr.dl.sourceforge.net/project/mplayer-win32/MPlayer%20and%20MEncoder/r38135%2Bgb272d5b9b6/MPlayer-generic-r38135%2Bgb272d5b9b6.7z
 - grepbin: http://downloads.sourceforge.net/gnuwin32/grep-2.5.4-bin.zip

--- a/Age of Empires/Age of Empires - CD.txt
+++ b/Age of Empires/Age of Empires - CD.txt
@@ -17,21 +17,14 @@ installer:
     arch: win64
     name: create_prefix
     prefix: $GAMEDIR
-- input_menu:
-    description: 'Please select your CD language:'
-    id: VERSION
-    options:
-    - aoeinst.exe: English or other
-    - aoesetup.exe: German
-    preselect: aoeinst.exe
 - insert-disc:
-    requires: empires.ico
+    requires: aoeinst.exe
 - task:
     app: winxp
     name: winetricks
     prefix: $GAMEDIR
 - task:
-    args: /desktop=AgeOfEmpiresI,1024x780 $DISC/$INPUT_VERSION
+    args: /desktop=AgeOfEmpiresI,1024x780 $DISC/aoeinst.exe
     description: Installing Age of Empires I...
     executable: $GAMEDIR/drive_c/windows/explorer.exe
     name: wineexec

--- a/Age of Empires/Age of Empires - Rise of Rome - CD.txt
+++ b/Age of Empires/Age of Empires - Rise of Rome - CD.txt
@@ -16,8 +16,15 @@ installer:
     file: updt
 - insert-disc:
     requires: game/empiresx.exe
+- input_menu:
+    description: 'Please select your CD language:'
+    id: VERSION
+    options:
+    - aoeinst.exe: English or other
+    - aoesetup.exe: German
+    preselect: aoeinst.exe
 - task:
-    args: /desktop=ROR,1024x780 $DISC/AOEinst.Exe
+    args: /desktop=ROR,1024x780 $DISC/$INPUT_VERSION
     description: Installing Rise of Rome extension...
     executable: $GAMEDIR/drive_c/windows/explorer.exe
     name: wineexec

--- a/Age of Empires/Age of Empires - Rise of Rome - CD.txt
+++ b/Age of Empires/Age of Empires - Rise of Rome - CD.txt
@@ -16,15 +16,8 @@ installer:
     file: updt
 - insert-disc:
     requires: game/empiresx.exe
-- input_menu:
-    description: 'Please select your CD language:'
-    id: VERSION
-    options:
-    - aoeinst.exe: English or other
-    - aoesetup.exe: German
-    preselect: aoeinst.exe
 - task:
-    args: /desktop=ROR,1024x780 $DISC/$INPUT_VERSION
+    args: /desktop=ROR,1024x780 $DISC/AOEinst.Exe
     description: Installing Rise of Rome extension...
     executable: $GAMEDIR/drive_c/windows/explorer.exe
     name: wineexec

--- a/Age of Empires/clean.sh
+++ b/Age of Empires/clean.sh
@@ -1,40 +1,43 @@
 #!/bin/bash
 
-lang=$1
-cdpath=$2
-aoeversion=$3
-
-cd "drive_c/Program Files (x86)/Microsoft Games/Age of Empires"
-
-ls | grep -iw avi | xargs rm -fr
-ls | grep -i empires.exe | xargs -I {} mv {} empires.exe.bak
-ls | grep -i language.dll | xargs -I {}  mv {} language.dll.bak
-
-if [ $aoeversion = "gold" ] || [ $aoeversion = "ror" ]
-then
-ls | grep -i empiresx.exe | xargs -I {}  mv {} empiresx.exe.bak
-else
-echo "Cette version n'est pas une Gold édition ni l'extension ROR"
-fi
-
-dirtmp="../../../tmp"
-
-echo "update de la version $aoeversion en $lang"
-if [ $aoeversion = "gold" ] || [ $aoeversion = "ror" ]
-then
-cp "$dirtmp/exe/"* .
-elif [ $aoeversion = "standard" ] 
-then
-cp "$dirtmp/exe/empires.exe" .
-fi
-
-cp "$dirtmp/$lang/"* .
-echo "$dirtmp/exe/" "$dirtmp/$lang/"
-#rm -f -r "$dirtmp"
-mkdir avi
-avipath=$(find "$cdpath" |grep -i -m1 avi)
-echo "$avipath"
-cp "$avipath/"* avi/
+#lang=$1
+#cdpath=$2
+#aoeversion=$3
+#
+#cd "drive_c/Program Files (x86)/Microsoft Games/Age of Empires"
+#
+#ls | grep -iw avi | xargs rm -fr
+#ls | grep -i empires.exe | xargs -I {} mv {} empires.exe.bak
+#ls | grep -i language.dll | xargs -I {}  mv {} language.dll.bak
+#
+#if [ $aoeversion = "gold" ] || [ $aoeversion = "ror" ]
+#then
+#ls | grep -i empiresx.exe | xargs -I {}  mv {} empiresx.exe.bak
+#else
+#echo "Cette version n'est pas une Gold édition ni l'extension ROR"
+#fi
+#
+#dirtmp="../../../tmp"
+#
+#echo "update de la version $aoeversion en $lang"
+#if [ $aoeversion = "gold" ] || [ $aoeversion = "ror" ]
+#then
+#cp "$dirtmp/exe/"* .
+#elif [ $aoeversion = "standard" ] 
+#then
+#cp "$dirtmp/exe/empires.exe" .
+#fi
+#
+#cp "$dirtmp/$lang/"* .
+#echo "$dirtmp/exe/" "$dirtmp/$lang/"
+##rm -f -r "$dirtmp"
+#mkdir avi
+#avipath=$(find "$cdpath" |grep -i -m1 avi)
+#echo "$avipath"
+#cp "$avipath/"* avi/
 
 # Delete installation batch file
-[ -e installaoe.bat ] && rm installaoe.bat
+if [ -e installaoe.bat ]
+then
+  rm installaoe.bat
+fi

--- a/Age of Empires/clean.sh
+++ b/Age of Empires/clean.sh
@@ -36,3 +36,5 @@ avipath=$(find "$cdpath" |grep -i -m1 avi)
 echo "$avipath"
 cp "$avipath/"* avi/
 
+# Delete installation batch file
+[ -e installaoe.bat ] && rm installaoe.bat

--- a/Age of Empires/findaoe.sh
+++ b/Age of Empires/findaoe.sh
@@ -6,4 +6,4 @@ setupfile=$(grep -E '^open=[A-Za-z]+\.exe' $cdpath/autorun.inf | grep -Eo '[A-Za
 echo "Determined name of executable to be $setupfile"
 
 winpath=$(sed -e 's#/#\\#g' <<< "$cdpath/$setupfile")
-echo $winpath > installaoe.bat
+echo "Z:$winpath" > installaoe.bat

--- a/Age of Empires/findaoe.sh
+++ b/Age of Empires/findaoe.sh
@@ -2,17 +2,8 @@
 
 cdpath=$1
 
-if [ $(find "$cdpath" |grep -i "aoeinst.exe") ]
-then
-echo "found aoeinst.exe"
-setupfile="aoeinst.exe"
-elif [ $(find "$cdpath" |grep -i "aoesetup.exe") ]
-then
-echo "found aoesetup.exe"
-setupfile="aoesetup.exe"
-else
-echo "AOE setup file not found"
-exit
-fi
-echo "$cdpath""$setupfile">test.bat
+setupfile=$(grep -E '^open=[A-Za-z]+\.exe' $cdpath/autorun.inf | grep -Eo '[A-Za-z]+\.exe')
+echo "Determined name of executable to be $setupfile"
 
+winpath=$(sed -e 's#/#\\#g' <<< "$cdpath/$setupfile")
+echo $winpath > installaoe.bat


### PR DESCRIPTION
The german CD has a different name for the setup exe, so the following
changes were implemented:

* Changes disc identification to `empires.ico` (In the hope that this is
names identically in each version)
* Added user input for choosing language and therefore filename of the
installation exe