### PR TITLE
Machinarium: fix extractor (switch to innoextract)

### DIFF
--- a/Machinarium/Machinarium Collector's Edition - GOG - Wine.txt
+++ b/Machinarium/Machinarium Collector's Edition - GOG - Wine.txt
@@ -1,6 +1,7 @@
 custom-name: Machinarium Collector's Edition - GOG - Wine
 files:
-- install: N/A:Please select the Humble archive
+- install: N/A:Please select the GOG installer
+- innoextract: https://constexpr.org/innoextract/files/innoextract-1.8-linux.tar.xz
 game:
   exe: drive_c/GOG Games/Machinarium/Machinarium.exe
   prefix: $GAMEDIR/
@@ -13,8 +14,11 @@ installer:
     name: create_prefix
     prefix: $GAMEDIR
 - extract:
-    dst: $CACHE
-    src: install
+    file: innoextract
+    dst: $CACHE/tmp/innoextract
+- execute:
+    args: --extract --exclude-temp --gog --output-dir $CACHE $install
+    file: $CACHE/tmp/innoextract/innoextract
 - merge:
     dst: $GAMEDIR/drive_c/GOG Games/Machinarium/
     src: $CACHE/app
@@ -31,4 +35,3 @@ installer:
       webcache.zip
 wine:
   Desktop: true
-


### PR DESCRIPTION
Current extractor (plain p7zip) supposedly fails to process GOG installer (setup_machinarium_2844-a_(18752).exe) so it was replaced with a valid extractor (innoextract):

```
DEBUG    2020-01-05 19:12:46,066 [interpreter._iter_commands:573]:Installer command: {'extract': {'dst': '$CACHE', 'src': 'install'}}
DEBUG    2020-01-05 19:12:46,068 [commands.extract:173]:Extracting setup_machinarium_2844-a_(18752).exe
DEBUG    2020-01-05 19:12:46,068 [commands.extract:177]:extracting file /media/sf_ara/adventum_ark/images/machinarium/setup_machinarium_2844-a_(18752).exe to /home/robert/.cache/lutris/installer/machinarium
DEBUG    2020-01-05 19:12:46,182 [extract.extract_archive:69]:Extracting /media/sf_ara/adventum_ark/images/machinarium/setup_machinarium_2844-a_(18752).exe to /home/robert/.cache/lutris/installer/machinarium
ERROR: /media/sf_ara/adventum_ark/images/machinarium/setup_machinarium_2844-a_(18752).exe
Can not open the file as archive

ERROR    2020-01-05 19:12:46,228 [jobs.target:32]:Error while completing task <bound method CommandsMixin.extract of <lutris.installer.interpreter.ScriptInterpreter object at 0x7f61581b3198>>: specified exe is not an archive or GOG setup file
  File "/ara/devel/lutris/lutris/util/jobs.py", line 30, in target
    result = self.function(*args, **kwargs)
  File "/ara/devel/lutris/lutris/installer/commands.py", line 179, in extract
    extract.extract_archive, filename, dest_path, merge_single, extractor
  File "/ara/devel/lutris/lutris/installer/commands.py", line 526, in _killable_process
    result = result_obj.get()  # Wait process end & reraise exceptions
  File "/usr/lib/python3.6/multiprocessing/pool.py", line 644, in get
    raise self._value

7-Zip (a) [64] 16.02 : Copyright (c) 1999-2016 Igor Pavlov : 2016-05-21
p7zip Version 16.02 (locale=en_US.UTF-8,Utf16=on,HugeFiles=on,64 bits,2 CPUs x64)

Scanning the drive for archives:
1 file, 410649096 bytes (392 MiB)

Testing archive: /media/sf_ara/adventum_ark/images/machinarium/setup_machinarium_2844-a_(18752).exe

Can't open as archive: 1
Files: 0
Size:       0
Compressed: 0
<class 'RuntimeError'> specified exe is not an archive or GOG setup file
```

There was also a type ("Humble" instead of "GOG").

P.S. there is something wrong with your repo. It takes 1.5GB (!) when cloned from github. Too much for a few scripts. My IDE literally dies when I'm trying to open a project folder. 
On my machine it's:
> ./.git/objects/pack/pack-5d5e504a57c665d4fc5af13ba84f4d475d8649bb.pack

which takes a gig of space.
There is also unreal patch which takes 100MB.
Please use Git LFS or something...