### PR TITLE
RollerCoaster Tycoon 2: Fixed installer and missing library

### DIFF
--- a/RollerCoaster Tycoon 2/RollerCoaster Tycoon 2 - OpenRCT2 Linux 64 bits.txt
+++ b/RollerCoaster Tycoon 2/RollerCoaster Tycoon 2 - OpenRCT2 Linux 64 bits.txt
@@ -1,6 +1,6 @@
 custom-name: RollerCoaster Tycoon 2 - GOG - Linux 64 bits
 files:
-- orct2lin1: https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.3.1/OpenRCT2-0.3.1-linux-x86_64.gz
+- orct2lin1: https://github.com/OpenRCT2/OpenRCT2/releases/download/v0.3.1/OpenRCT2-0.3.1-linux-x86_64.tar.gz
 - orct2lin2: https://github.com/legluondunet/MyLittleLutrisScripts/raw/master/RollerCoaster%20Tycoon%202/OpenRCT2_x64_portable_addons_files.tar.xz
 - inno: http://constexpr.org/innoextract/files/snapshots/innoextract-1.8-dev-2019-01-13/innoextract-1.8-dev-2019-01-13-linux.tar.xz
 - rct2setup: N/A:Select the EXE downloaded from GOG


### PR DESCRIPTION
This fixes the issues #48 and #49 .