### PR TITLE
add d3dx9_34 and remove the wine virtual desktop

### DIFF
--- a/Warhammer Online - Return of Reckoning/Warhammer Online - Return of Reckoning.txt
+++ b/Warhammer Online - Return of Reckoning/Warhammer Online - Return of Reckoning.txt
@@ -15,7 +15,7 @@ installer:
     dst: $GAMEDIR/drive_c/Program Files (x86)/Return of Reckoning
     src: $DISC
 - task:
-    app: dotnet40 dxvk
+    app: dotnet40 dxvk d3dx9_34
     name: winetricks
     prefix: $GAMEDIR
 - task:
@@ -24,14 +24,6 @@ installer:
     path: HKEY_CURRENT_USER\Software\Wine\AppDefaults\RoRLauncher.exe\DllOverrides
     type: REG_SZ
     value: builtin
-- task:
-    arch: win64
-    key: background
-    name: set_regedit
-    path: HKEY_CURRENT_USER\Control Panel\Colors\
-    prefix: $GAMEDIR
-    type: REG_SZ
-    value: 0 0 0
 wine:
   Desktop: true
   dxvk: false


### PR DESCRIPTION
d3dx9_34 is needt in order to render the game correctly.
wine virtual desktop by default is unnecessary and may cause some cursor lock issues depending on the WM