### PR TITLE
Update TR2M.BAT

### DIFF
--- a/Tomb Raider II/TR2M.BAT
+++ b/Tomb Raider II/TR2M.BAT
@@ -1,6 +1,7 @@
 @echo off
 color 4E
 c:\
+DEL "C:\Tomb Raider 2\Tomb2.dxvk-cache"
 goto launcher
 
 


### PR DESCRIPTION
TR2 wouldnt start after the first inital Setup and playing. Everytime i used option 3 --> Nothing would happen. Using Option 1 --> Game closes/Crashes.
After some tinkering i looked at the newly created files and deleting the "Tomb2.dxvk-cache" fixed the issue.

Running on Linux Mint 19.3 Cinnamon on a Lenovo Carbon X1. Installed the Game using the Lutris install script for the GOG Version.