### PR TITLE
[#100 | Syberia] Fix black screen on game launch

### DIFF
--- a/Syberia/Syberia.bat
+++ b/Syberia/Syberia.bat
@@ -17,7 +17,7 @@ echo  %result%
 IF %result% NEQ 0 GOTO :search
 
 
-start nircmd.exe cmdwait 1000 win hide title Syberia
-start nircmd.exe cmdwait 1000 win hideshow title Syberia
+start nircmd.exe cmdwait 100 win hide title Syberia
+start nircmd.exe cmdwait 100 win hideshow title Syberia
 
 exit


### PR DESCRIPTION
Change nircmd.exe delay to 100 ms as per https://appdb.winehq.org/objectManager.php?sClass=version&iId=19734&iTestingId=100474 to fix the black screen on game launch.