### PR TITLE
RTCW: Remove leading whitespace from launch script

### DIFF
--- a/Return to Castle Wolfenstein/realrtcw.sh
+++ b/Return to Castle Wolfenstein/realrtcw.sh
@@ -1,2 +1,2 @@
-    #!/bin/bash
+#!/bin/bash
 ./RealRTCW.x86_64 +set fs_homepath .


### PR DESCRIPTION
After installation, the game does not start.

In the logs the following error can be found:

````
Running $HOME_DIR/Games/gog/return-to-castle-wolfenstein/iowolf.sh
Traceback (most recent call last):
  File "/usr/share/lutris/bin/lutris-wrapper", line 235, in <module>
    main()
  File "/usr/share/lutris/bin/lutris-wrapper", line 120, in main
    initial_pid = subprocess.Popen(args).pid
  File "/usr/lib/python3.9/subprocess.py", line 951, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/lib/python3.9/subprocess.py", line 1823, in _execute_child
    raise child_exception_type(errno_num, err_msg, err_filename)
OSError: [Errno 8] Exec format error: '$HOME_DIR/Games/gog/return-to-castle-wolfenstein/iowolf.sh'
````

Removing the whitespace at the beginning of the script fixes the issue.