### PR TITLE
fix(aoe/clean.sh): Don't use grep to find files

### DIFF
--- a/Age of Empires/clean.sh
+++ b/Age of Empires/clean.sh
@@ -6,15 +6,15 @@ aoeversion=$3
 
 cd "drive_c/Program Files (x86)/Microsoft Games/Age of Empires"
 
-ls | grep -iw avi | xargs rm -fr
-ls | grep -i empires.exe | xargs -I {} mv {} empires.exe.bak
-ls | grep -i language.dll | xargs -I {}  mv {} language.dll.bak
+find ./ -type d -iname avi -delete
+find ./ -type f -iname empires.exe -exec mv {} empires.exe.bak \;
+find ./ -type f -iname language.dll -exec mv {} language.dll.bak \;
 
 if [ $aoeversion = "gold" ] || [ $aoeversion = "ror" ]
 then
-ls | grep -i empiresx.exe | xargs -I {}  mv {} empiresx.exe.bak
+    find ./ -type f -iname empiresx.exe -exec mv {} empiresx.exe.bak \;
 else
-echo "Cette version n'est pas une Gold édition ni l'extension ROR"
+    echo "Cette version n'est pas une Gold édition ni l'extension ROR"
 fi
 
 dirtmp="../../../tmp"
@@ -22,19 +22,19 @@ dirtmp="../../../tmp"
 echo "update de la version $aoeversion en $lang"
 if [ $aoeversion = "gold" ] || [ $aoeversion = "ror" ]
 then
-cp "$dirtmp/exe/"* .
-ls | grep -ix empiresx.exe | xargs -I {} cp {} empiresx1a.exe
-cp "../../../aoe1covers/1.bmp" "../../../aoe1.bmp"
+    cp "$dirtmp/exe/"* .
+    find ./ -type f -iname empiresx.exe -exec cp {} empiresx1a.exe \;
+    cp "../../../aoe1covers/1.bmp" "../../../aoe1.bmp"
 elif [ $aoeversion = "standard" ] 
 then
-cp "$dirtmp/exe/empires.exe" .
+    cp "$dirtmp/exe/empires.exe" .
 fi
 
 cp "$dirtmp/$lang/"* .
 echo "$dirtmp/exe/" "$dirtmp/$lang/"
 rm -f -r "$dirtmp"
 mkdir avi
-avipath=$(find "$cdpath" |grep -i -m1 avi)
+avipath=$(find "$cdpath" -type d -iname avi)
 echo "$avipath"
 cp "$avipath/"* avi/
 


### PR DESCRIPTION
Changes:
- Replace grepping in listing outputs with find
- Replace acting on files using xargs with the -exec function of find
- Add indentions to improve readability

The output ls is mainly designed to be human readable, therefore parsing it's output is fragile. Also grep is a tool for pattern matching, that doesn't know about filenames and operates on a "line" base (at least by default). This can cause false positives and therefore errors. Since this script already uses find and therefore requires this tool to be present, we might as well use it. This also allows to ditch xargs, since it can be substituted with finds own functionality (-exec).