### PR TITLE
Update TR1 for compatibility with Lutris Flatpak

### DIFF
--- a/Tomb Raider I/Tomb Raider 1 - GOG - TombATI HD.txt
+++ b/Tomb Raider I/Tomb Raider 1 - GOG - TombATI HD.txt
@@ -62,8 +62,9 @@ installer:
     src: cdrtools
 - execute:
     command: cd "$CACHE/app"; ./bin2iso game.cue -c GAME.GOG ;./bin2iso game.cue;
-      if [ -f "GAME-01.iso" ]; then cd=GAME-01.iso; else  cd=GAME.GOG; fi; echo $cd;
-      ./7z x -y $cd;
+- extract:
+    dst: $CACHE/app
+    src: $CACHE/app/GAME-01.iso
 - merge:
     dst: $GAMEDIR/drive_c/TOMBATI/DATA
     src: $CACHE/app/DATA

--- a/Tomb Raider I/Tomb Raider 1 - Steam - TombATI HD.txt
+++ b/Tomb Raider I/Tomb Raider 1 - Steam - TombATI HD.txt
@@ -61,8 +61,9 @@ installer:
     src: $DISC
 - execute:
     command: cd "$CACHE/app"; ./bin2iso game.cue -c GAME.GOG ;./bin2iso game.cue;
-      if [ -f "GAME-01.iso" ]; then cd=GAME-01.iso; else  cd=GAME.GOG; fi; echo $cd;
-      ./7z x -y $cd;
+- extract:
+    dst: $CACHE/app
+    src: $CACHE/app/GAME-01.iso
 - merge:
     dst: $GAMEDIR/drive_c/TOMBATI/DATA/
     src: $CACHE/app/DATA

--- a/Tomb Raider I/Tomb Raider I - GOG - Tomb1Main.txt
+++ b/Tomb Raider I/Tomb Raider I - GOG - Tomb1Main.txt
@@ -26,9 +26,10 @@ installer:
     dst: $GAMEDIR/drive_c/tmp
     src: cdrtools
 - execute:
-    command: cd "$GAMEDIR/drive_c/tmp"; ./bin2iso game.cue -c GAME.GOG ;./bin2iso
-      game.cue; if [ -f "GAME-01.iso" ]; then cd=GAME-01.iso; else  cd=GAME.GOG; fi;
-      echo $cd; ./7z x -y $cd;
+    command: cd "$GAMEDIR/drive_c/tmp"; ./bin2iso game.cue -c GAME.GOG ;./bin2iso game.cue;
+- extract:
+    dst: $GAMEDIR/drive_c/tmp/app
+    src: $GAMEDIR/drive_c/tmp/app/GAME-01.iso
 - merge:
     dst: $GAMEDIR/drive_c/TOMB1Main/DATA
     src: $GAMEDIR/drive_c/tmp/DATA

--- a/Tomb Raider I/Tomb Raider I - Steam - Tomb1Main.txt
+++ b/Tomb Raider I/Tomb Raider I - Steam - Tomb1Main.txt
@@ -27,9 +27,10 @@ installer:
     dst: $GAMEDIR/drive_c/tmp
     src: cdrtools
 - execute:
-    command: cd "$GAMEDIR/drive_c/tmp"; ./bin2iso game.cue -c GAME.GOG ;./bin2iso
-      game.cue; if [ -f "GAME-01.iso" ]; then cd=GAME-01.iso; else  cd=GAME.GOG; fi;
-      echo $cd; ./7z x -y $cd;
+    command: cd "$GAMEDIR/drive_c/tmp"; ./bin2iso game.cue -c GAME.GOG ;./bin2iso game.cue;
+- extract:
+    dst: $GAMEDIR/drive_c/tmp/app
+    src: $GAMEDIR/drive_c/tmp/app/GAME-01.iso
 - merge:
     dst: $GAMEDIR/drive_c/TOMB1Main/DATA
     src: $GAMEDIR/drive_c/tmp/DATA


### PR DESCRIPTION
This should fix #137. I don't have a Steam Deck, but the changed scripts fixed that issue for me using the Flatpak version of Lutris on Fedora 38. I've tested the GOG versions of the scripts, but not the Steam versions since I don't have the game on Steam.

I'm not entirely sure what that script block was supposed to do? 7z can't extract GAME.GOG (at least not the current version) and I don't understand how it would ever end up in the `cd=GAME.GOG` branch, never mind that it would do anything but crash.