### PR TITLE
Brood War: filter out irrelevant install.exe match.

### DIFF
--- a/Starcraft - Brood War/Starcraft Brood War - CD.txt
+++ b/Starcraft - Brood War/Starcraft Brood War - CD.txt
@@ -16,5 +16,5 @@ installer:
     name: wineexec
 - execute:
     command: cd "$GAMEDIR/drive_c/Program Files (x86)/Starcraft"; find "$DISC/"* -iname
-      install.exe | xargs -I {} cp {} BroodWar.mpq; chmod +rw BroodWar.mpq;
+      install.exe -not -ipath '*mindspr*' | xargs -I {} cp {} BroodWar.mpq; chmod +rw BroodWar.mpq;
 requires: starcraft-cd-cnc-draw


### PR DESCRIPTION
With my Brood War CD, the find command run by this Lutris installer matches two INSTALL.EXEs:

```
./broodwar/INSTALL.EXE
./broodwar/ISP/MINDSPR/INSTALL.EXE
```

The first one gets copied to BroodWar.mpq to remove the need to play with a CD inserted, but then the second one overwrites it.

This pull request just ignores the second one, which is some kind of trial for a long-gone dial-up ISP. This gets the game to stop asking for a CD.