### PR TITLE
Update Unreal Gold - CD - patch 227j.txt

### DIFF
--- a/Unreal Gold/Unreal Gold - CD - patch 227j.txt
+++ b/Unreal Gold/Unreal Gold - CD - patch 227j.txt
@@ -3,9 +3,9 @@ files:
 - patch2: https://github.com/legluondunet/MyLittleLutrisScripts/raw/master/Unreal%20Gold/UPakFonts.tar.xz
 - linuxlibs: https://github.com/legluondunet/MyLittleLutrisScripts/raw/master/Unreal%20Gold/unreal_gold_lib64.tar.xz
 game:
-  exe: drive_c/UnrealGold/System64/Unreal.exe
+  exe: drive_c/Unreal/System64/Unreal.exe
   launch_configs:
-  - exe: $GAMEDIR/drive_c/UnrealGold/System64/UnrealLinux.bin
+  - exe: $GAMEDIR/drive_c/Unreal/System64/UnrealLinux.bin
     name: Unreal Linux native version
   prefix: $GAMEDIR
 installer:
@@ -25,15 +25,15 @@ installer:
     name: wineexec
     prefix: $GAMEDIR
 - extract:
-    dst: $GAMEDIR/drive_c/UnrealGold/lib64
+    dst: $GAMEDIR/drive_c/Unreal/lib64
     file: linuxlibs
 - extract:
-    dst: $GAMEDIR/drive_c/UnrealGold
+    dst: $GAMEDIR/drive_c/Unreal
     file: patch1
 - extract:
-    dst: $GAMEDIR/drive_c/UnrealGold/Textures
+    dst: $GAMEDIR/drive_c/Unreal/Textures
     file: patch2
-- chmodx: $GAMEDIR/drive_c/UnrealGold/System64/UnrealLinux.bin
+- chmodx: $GAMEDIR/drive_c/Unreal/System64/UnrealLinux.bin
 - input_menu:
     description: 'Choose your game''s language:'
     id: LANG
@@ -64,7 +64,7 @@ installer:
         WindowedColorBits: 32
         WindowedViewportX: $RESOLUTION_WIDTH
         WindowedViewportY: $RESOLUTION_HEIGHT
-    file: $GAMEDIR/drive_c/UnrealGold/System64/Default.ini
+    file: $GAMEDIR/drive_c/Unreal/System64/Default.ini
     merge: true
 - write_config:
     data:
@@ -72,7 +72,7 @@ installer:
         DefaultFOV: 106.4
         DesiredFOV: 106.4
         MainFOV: 106.4
-    file: $GAMEDIR/drive_c/UnrealGold/System64/DefUser.ini
+    file: $GAMEDIR/drive_c/Unreal/System64/DefUser.ini
     merge: true
 - write_config:
     data:
@@ -94,19 +94,19 @@ installer:
         WindowedColorBits: 32
         WindowedViewportX: $RESOLUTION_WIDTH
         WindowedViewportY: $RESOLUTION_HEIGHT
-    file: $GAMEDIR/drive_c/UnrealGold/System64/DefaultLinux.ini
+    file: $GAMEDIR/drive_c/Unreal/System64/DefaultLinux.ini
     merge: true
 - move:
     dst: $CACHE
-    src: $GAMEDIR/drive_c/UnrealGold/System64/Unreal.ini
+    src: $GAMEDIR/drive_c/Unreal/System64/Unreal.ini
 - move:
     dst: $CACHE
-    src: $GAMEDIR/drive_c/UnrealGold/System64/UnrealLinux.ini
+    src: $GAMEDIR/drive_c/Unreal/System64/UnrealLinux.ini
 - move:
     dst: $CACHE
-    src: $GAMEDIR/drive_c/UnrealGold/System64/User.ini
+    src: $GAMEDIR/drive_c/Unreal/System64/User.ini
 system:
   env:
     DXVK_FRAME_RATE: '60'
     DXVK_HUD: ''
-  prefix_command: LD_LIBRARY_PATH="$GAMEDIR/drive_c/UnrealGold/lib64"
+  prefix_command: LD_LIBRARY_PATH="$GAMEDIR/drive_c/Unreal/lib64"


### PR DESCRIPTION
Needed to fix this since the updated files get installed into the `UnrealGold` folder instead of the default installer's `Unreal` folder. Without the fix, you'll get an error message that hints that the `Entry` map can't be found:

![Screenshot_20241120_135200](https://github.com/user-attachments/assets/4ad1880e-fe29-48af-876e-d8d2a767b0e7)

Verified this then by looking at the Lutris game folder of that installation, where after the fresh installation via this unmodified script, the two folders exist:

![Screenshot_20241120_135133](https://github.com/user-attachments/assets/eafe2bea-0b92-4ecc-80c2-90dcc4209619)

It is mentioned in the setup task instructions to keep all things at their default settings:
```yaml
- task:
    description: Running setup of the game. Just proceed and keep all settings at
      their defaults
```
The installer's default install destination is just `Unreal`, hence this quick fix PR:
![Screenshot_20241120_134927](https://github.com/user-attachments/assets/1f885a07-572d-47f6-8276-9363fb64f122)

I used the Epic Games "sanctioned" Unreal Gold iso to verify this:
```bash
$ md5sum Unreal\ Gold\ verified.iso
84d6b80125ab745644c269bb44e5ae39  Unreal Gold verified.iso
$ sha1sum Unreal\ Gold\ verified.iso
1957ece469b32bcdcd3ec9079407907e6b4b88cb  Unreal Gold verified.iso
```

After the fix, the game runs just fine (tested on Fedora 41).

Thanks a lot for this great combined Lutris installer script :ok_hand: !