### PR TITLE
fix: Civilization IV command fails on paths with spaces

### DIFF
--- a/Civilization IV/Civilization IV - GOG.txt
+++ b/Civilization IV/Civilization IV - GOG.txt
@@ -39,7 +39,7 @@ installer:
 - execute:
     command: sed -i -e 's/ScreenWidth = 0/ScreenWidth = '$RESOLUTION_WIDTH'/g' -e
       's/ScreenHeight = 0/ScreenHeight = '$$RESOLUTION_HEIGHT'/g' -e 's/Language =
-      0/Language = '$INPUT_LANG'/g' $game_cfg;
+      0/Language = '$INPUT_LANG'/g' "$game_cfg";
 - merge:
     dst: $GAMEDIR/drive_c/users/$USER/Documents/My Games/Beyond the Sword
     src: game_cfg


### PR DESCRIPTION
If the path where the ini file was saved contains spaces the script fails because it has no quotes.